### PR TITLE
Fixed gravity when holding objects

### DIFF
--- a/Assets/Scenes/Levels/Level0.unity
+++ b/Assets/Scenes/Levels/Level0.unity
@@ -1028,6 +1028,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &130602912 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3784293241610158376, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+  m_PrefabInstance: {fileID: 1664888674}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &157347874
 GameObject:
   m_ObjectHideFlags: 0
@@ -2327,6 +2332,17 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 389500335}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &391627030 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9009892228891423777, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+  m_PrefabInstance: {fileID: 1664888674}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &400840674
 GameObject:
   m_ObjectHideFlags: 0
@@ -7971,15 +7987,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1750328265095541324, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -28.75
+      value: 182.90002
       objectReference: {fileID: 0}
     - target: {fileID: 1750328265095541324, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.375002
+      value: 17.574999
       objectReference: {fileID: 0}
     - target: {fileID: 1750328265095541324, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.6000016
+      value: -249.70001
       objectReference: {fileID: 0}
     - target: {fileID: 2416929007388417668, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: spawnPoint
@@ -7987,23 +8003,39 @@ PrefabInstance:
       objectReference: {fileID: 1895889953157971715}
     - target: {fileID: 4976584202734474264, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -28.75
+      value: -2.1091805
       objectReference: {fileID: 0}
     - target: {fileID: 4976584202734474264, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.375002
+      value: 0.34578514
       objectReference: {fileID: 0}
     - target: {fileID: 4976584202734474264, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.6000016
+      value: 80.63581
       objectReference: {fileID: 0}
     - target: {fileID: 4976584202734474264, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4976584202734474264, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5647112630155608246, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: MainCamera
+      value: 
+      objectReference: {fileID: 1981867430}
+    - target: {fileID: 5647112630155608246, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: playerCamRoot
+      value: 
+      objectReference: {fileID: 130602912}
+    - target: {fileID: 5647112630155608246, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: VirtualCamera3D
+      value: 
+      objectReference: {fileID: 391627030}
+    - target: {fileID: 6106370532408573120, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33.619312
       objectReference: {fileID: 0}
     - target: {fileID: 6106370532408573120, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8049,11 +8081,51 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7290586444352009121, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: field of view
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 9009892228891423777, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: m_Transitions.m_InheritPosition
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9124290187480717203, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 182.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9124290187480717203, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 14.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9124290187480717203, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -224.7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3202933135401273191, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1696360514}
   m_SourcePrefab: {fileID: 100100000, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+--- !u!1 &1696360510 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3202933135401273191, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+  m_PrefabInstance: {fileID: 1664888674}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1696360514
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696360510}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e8b78ac948f05a46a6d8339a503172b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1707799148 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1656875805664294110, guid: 81c6d3233c8aae24aa9b2e8c1e7b68ba, type: 3}
@@ -9075,6 +9147,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &1981867430 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6774737294069508098, guid: 10b144c380968504d935c9e3949f6f80, type: 3}
+  m_PrefabInstance: {fileID: 1664888674}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2007466653
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Player/PlayerDimensionController.cs
+++ b/Assets/Script/Player/PlayerDimensionController.cs
@@ -2,6 +2,7 @@ using StarterAssets;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
+using Cinemachine;
 
 public class PlayerDimensionController : MonoBehaviour {
     public const float WALL_DRAW_OFFSET = .21f;
@@ -17,6 +18,8 @@ public class PlayerDimensionController : MonoBehaviour {
 
 
     [Header("Cameras")]
+    [SerializeField] private GameObject playerCamRoot;
+    [SerializeField] private CinemachineVirtualCamera VirtualCamera3D;
     [SerializeField] private GameObject Camera3D;
     [SerializeField] private GameObject Camera2D;
 
@@ -168,10 +171,10 @@ public class PlayerDimensionController : MonoBehaviour {
         player3D.SetActive(false);
 
         PlayerBehaviour.Instance.ChangeDimension();
-
-
         Camera3D.SetActive(false);
         Camera2D.SetActive(true);
+        VirtualCamera3D.LookAt = player2D.transform;
+        VirtualCamera3D.Follow = Camera2D.transform;
         //tell the movement controller to lock axes
         movementController_2D.ProcessAxisChange();
         if (player3D.TryGetComponent(out StarterAssetsInputs sAssetsInput)) {
@@ -187,8 +190,6 @@ public class PlayerDimensionController : MonoBehaviour {
         MovePlayerOutOfWall(player2D.transform.position + player2D.transform.forward * playerLeaveWallOffset);
         Debug.Log("turning physics back on");
         Physics.IgnoreLayerCollision(LayerInfo.PLAYER, LayerInfo.INTERACTABLE_OBJECT, false);
-
-
     }
     private void MovePlayerOutOfWall(Vector3 newPos) {
         player2D.SetActive(false);
@@ -201,6 +202,8 @@ public class PlayerDimensionController : MonoBehaviour {
         PlayerBehaviour.Instance.ChangeDimension();
         Camera3D.SetActive(true);
         Camera2D.SetActive(false);
+        VirtualCamera3D.LookAt = null;
+        VirtualCamera3D.Follow = playerCamRoot.transform;
         if (player3D.TryGetComponent(out StarterAssetsInputs sAssetsInput)) {
             sAssetsInput.ClearInput();
         }

--- a/Assets/Script/Player/PlayerDimensionController.cs
+++ b/Assets/Script/Player/PlayerDimensionController.cs
@@ -173,8 +173,7 @@ public class PlayerDimensionController : MonoBehaviour {
         PlayerBehaviour.Instance.ChangeDimension();
         Camera3D.SetActive(false);
         Camera2D.SetActive(true);
-        VirtualCamera3D.LookAt = player2D.transform;
-        VirtualCamera3D.Follow = Camera2D.transform;
+
         //tell the movement controller to lock axes
         movementController_2D.ProcessAxisChange();
         if (player3D.TryGetComponent(out StarterAssetsInputs sAssetsInput)) {
@@ -185,7 +184,8 @@ public class PlayerDimensionController : MonoBehaviour {
     }
     public void TransitionTo3D() {
 
-
+        VirtualCamera3D.LookAt = player2D.transform;
+        VirtualCamera3D.Follow = Camera2D.transform;
         //adjust the player 3d model to be in front of the wall offset by a small amount
         MovePlayerOutOfWall(player2D.transform.position + player2D.transform.forward * playerLeaveWallOffset);
         Debug.Log("turning physics back on");

--- a/Assets/prefabs/PlayerCameraWrapper.prefab
+++ b/Assets/prefabs/PlayerCameraWrapper.prefab
@@ -722,7 +722,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2817393637023723959}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -28.75, y: 3.375, z: -3.6000004}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1849,7 +1849,7 @@ MonoBehaviour:
   GroundedRadius: 4.5
   GroundLayers:
     serializedVersion: 2
-    m_Bits: 8576
+    m_Bits: 256
   CinemachineCameraTarget: {fileID: 3784293241610158376}
   TopClamp: 70
   BottomClamp: -30
@@ -2555,7 +2555,7 @@ Transform:
   m_GameObject: {fileID: 6774737294069508098}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: -80.390686, y: -28.839067, z: 18.905674}
+  m_LocalPosition: {x: -54.28069, y: 38.960938, z: 18.905674}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/prefabs/PlayerCameraWrapper.prefab
+++ b/Assets/prefabs/PlayerCameraWrapper.prefab
@@ -903,7 +903,7 @@ MonoBehaviour:
   CameraDistance: 25
   CameraCollisionFilter:
     serializedVersion: 2
-    m_Bits: 321
+    m_Bits: 4417
   IgnoreTag: Player
   CameraRadius: 0.15
   DampingIntoCollision: 0
@@ -1347,6 +1347,8 @@ MonoBehaviour:
   player2D: {fileID: 266677610665238099}
   movementController_2D: {fileID: 5895966758457165437}
   dog2DHitbox: {fileID: 7203371137855413276}
+  playerCamRoot: {fileID: 3784293241610158376}
+  VirtualCamera3D: {fileID: 9009892228891423777}
   Camera3D: {fileID: 2817393637023723959}
   Camera2D: {fileID: 74397854644777205}
   playerLeaveWallOffset: 6

--- a/Assets/prefabs/Puzzle Pieces/Cube.prefab
+++ b/Assets/prefabs/Puzzle Pieces/Cube.prefab
@@ -349,7 +349,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1024
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0

--- a/Assets/prefabs/Puzzle Pieces/TransferableSphere.prefab
+++ b/Assets/prefabs/Puzzle Pieces/TransferableSphere.prefab
@@ -351,7 +351,7 @@ SphereCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 1024
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0


### PR DESCRIPTION
Added exclude player layer on object colliders so they don't collide when the player is carrying them.

Also removed interactible objects from the ground layer to fix the super jump bug when holding a cube. This means we can't use jumping on cubes as a puzzle mechanic anymore (for now)